### PR TITLE
Add Netlify to credits

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -17,7 +17,7 @@
     <div class="text-small mt3">
       <p class="mt0 mb2">
         Content ©{{ site.time | date: "%Y" }} Joel Andrew Glovier. All rights reserved. <br>
-        Design and code (except graphics) are public and open source <a href="https://github.com/jglovier/jglovier.github.io" target="_blank">on GitHub</a>.
+        Design and code (except graphics) are public and open source <a href="https://github.com/jglovier/jglovier.github.io" target="_blank">on GitHub</a>, and hosted on <a href="https://www.netlify.com/">Netlify</a>.
       </p>
 
       <p class="mb2">

--- a/about/index.md
+++ b/about/index.md
@@ -27,8 +27,8 @@ I'd like to take a moment to acknowledge those who have offered their work for t
 
 ### Build details and tooling
 
-- This site was built with the static site generator [Jekyll](https://jekyllrb.com/), utilizing the templating language [Liquid](http://shopify.github.io/liquid/), and hosted on [GitHub Pages](https://pages.github.com/) from [this repository](github.com/jglovier/jglovier.github.io/).
-- This site was coded on [Atom](https://atom.io/), a hackable text editor for the 21st century.
+- This site was built with the static site generator [Jekyll](https://jekyllrb.com/), utilizing the templating language [Liquid](http://shopify.github.io/liquid/), and hosted on [Netlify](https://www.netlify.com/). Source code is available on [GitHub](github.com/jglovier/jglovier.github.io/).
+- This site was coded in [Atom](https://atom.io/), a hackable text editor for the 21st century.
 - Illustrations for this site were drawn with the [Apple iPad Pro](https://amzn.to/2G25JTT) and [Apple Pencil](https://amzn.to/2G5h69G) using the [ProCreate](https://itunes.apple.com/us/app/procreate/id425073498?mt=8) app.
 - Typography courtesy of Google Fonts:
   - [Montserrat](https://fonts.google.com/specimen/Montserrat) (headings)


### PR DESCRIPTION
Now that the site is hosted on Netlify instead of GitHub pages, this PR adds some credits to Netlify to the site credits page and footer.

✨🔷:sparkles: 