### PR TITLE
Fix: Missing protocol for link to GitHub repo

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -31,7 +31,7 @@ I'd like to take a moment to acknowledge those who have offered their work for t
 
 ### Build details and tooling
 
-- This site was built with the static site generator [Jekyll](https://jekyllrb.com/), utilizing the templating language [Liquid](http://shopify.github.io/liquid/), and hosted on [Netlify](https://www.netlify.com/). Source code is available on [GitHub](github.com/jglovier/jglovier.github.io/).
+- This site was built with the static site generator [Jekyll](https://jekyllrb.com/), utilizing the templating language [Liquid](http://shopify.github.io/liquid/), and hosted on [Netlify](https://www.netlify.com/). Source code is available on [GitHub](https://github.com/jglovier/jglovier.github.io/).
 - This site was coded in [Atom](https://atom.io/), a hackable text editor for the 21st century.
 - Illustrations for this site were drawn with the [Apple iPad Pro](https://amzn.to/2G25JTT) and [Apple Pencil](https://amzn.to/2G5h69G) using the [ProCreate](https://itunes.apple.com/us/app/procreate/id425073498?mt=8) app.
 - Typography courtesy of Google Fonts:


### PR DESCRIPTION
Add missing protocol for link to the GitHub repo.

_Sidenote: Love your new site!_