### PR TITLE
Add links to past site versions in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -20,11 +20,18 @@
         Design and code (except graphics) are open source <a href="https://github.com/jglovier/jglovier.github.io" target="_blank">on GitHub</a>. Hosted on <a href="https://www.netlify.com/">Netlify</a>.
       </p>
 
-      <p class="my0">
+      <p class="mt0 mb2">
         See the <a href="https://github.com/jglovier/jglovier.github.io/pull/70" target="_blank">pull request</a> for the current design, or read the <a
           href="/about#site-credits"
           class="regular">credits</a>. <br>
         Have feedback on this site? <a href="https://github.com/jglovier/jglovier.github.io/issues/new" target="_blank">Open an issue</a> (🙇). Or, <a href="https://github.com/jglovier/ama" target="_blank">AMA</a>!‍
+      </p>
+
+      <p class="my0">Older versions:  
+        <a href="https://2009.joelglovier.com/" target="_blank">2009</a> •
+        <a href="https://2011.joelglovier.com/" target="_blank">2011</a> •
+        <a href="https://2013.joelglovier.com/" target="_blank">2013</a> •
+         <a href="https://2015.joelglovier.com/" target="_blank">2015</a>
       </p>
     </div>
 


### PR DESCRIPTION
This PR makes a tiny change to the footer that adds links to past site versions. ✨ 🔧 ✨ 

| Before | After |
|---|---|
|![image](https://user-images.githubusercontent.com/1319791/133906732-cc14ecba-0001-4587-b70d-672ed7b68eb9.png)|![image](https://user-images.githubusercontent.com/1319791/133906739-01b12d88-d935-45cc-b71f-d1820bbc906a.png)|