### PR TITLE
Fix insecure content warning on Netlify deploys

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ name:           Joel Glovier's Blog
 
 description:    "The personal site of Joel Andrew Glovier, designer and front-end technologist. Where I write about code, design, faith, food, and life. Views expressed are my own. Use code at your own risk."
 
-url:            http://joelglovier.com
+url:            https://joelglovier.com
 
 plugins:
   - jekyll-redirect-from

--- a/_posts/2011-06-29-html5-rant.md
+++ b/_posts/2011-06-29-html5-rant.md
@@ -19,4 +19,4 @@ redirect_from:
 
 <p>So while I'm not arguing against HTML5 in place of Flash, I'm arguing that the way we talk about the topic should change, and become more relevant to the true implications of HTML5. Things like how it's not going to replace anyone technology, but the possibilities enabled by the HTML5 spec will make room for many other technologies in combination to replace many "purpose-served" technologies like Adobe Flash.</p>
 
-<p><code>&lt;/rant&gt;</p>
+<p><code>&lt;/rant&gt;</code></p>


### PR DESCRIPTION
This PR to fixes the insecure content warning on Netlify deploys by updating the http to https in the jekyll config file (related to how jekyll-redirect-from plugin generates new pages from the config site url).
